### PR TITLE
When checking class of an object, use 'inherits()' instead of 'class()'

### DIFF
--- a/R/InvestigatePrior_rm.R
+++ b/R/InvestigatePrior_rm.R
@@ -53,7 +53,7 @@ InvestigatePrior <- function(y, Z, X, ngrid = 50, q.seq = c(2, 1, 1/2, 1/4, 1/8,
       Kmat10 <- Kmat[(n0+1):nall,1:n0 ,drop=FALSE]
       U <- try(t(chol(K)), silent=TRUE)
       # all.equal(K, U %*% t(U))
-      if(class(U) == "try-error") {
+      if(inherits(U, "try-error")) {
         sigsvd <- svd(K)
         U <- t(sigsvd$v %*% (t(sigsvd$u) * sqrt(sigsvd$d)))
         # all.equal(K, U %*% t(U), check.attributes=FALSE)

--- a/R/bkmr_main_functions.R
+++ b/R/bkmr_main_functions.R
@@ -90,9 +90,9 @@ kmbayes <- function(y, Z, X = NULL, iter = 1000, family = "gaussian", id = NULL,
   ##Argument check 1, required arguments without defaults
   ##check vector/matrix sizes
   stopifnot (length(y) > 0, is.numeric(y), anyNA(y) == FALSE)
-  if (inherits(class(Z), "matrix") == FALSE)  Z <- as.matrix(Z)
+  if (!inherits(Z, "matrix"))  Z <- as.matrix(Z)
   stopifnot (is.numeric(Z), nrow(Z) == length(y), anyNA(Z) == FALSE)
-  if (inherits(class(X), "matrix") == FALSE)  X <- as.matrix(X)
+  if (!inherits(X, "matrix"))  X <- as.matrix(X)
   stopifnot (is.numeric(X), nrow(X) == length(y), anyNA(X) == FALSE) 
   
   ##Argument check 2: for those with defaults, write message and reset to default if invalid
@@ -133,11 +133,11 @@ kmbayes <- function(y, Z, X = NULL, iter = 1000, family = "gaussian", id = NULL,
     }
   }
   if (!is.null(Znew)) { 
-    if (class(Znew) != "matrix")  Znew <- as.matrix(Znew)
+    if (!inherits(Znew, "matrix"))  Znew <- as.matrix(Znew)
     stopifnot(is.numeric(Znew), ncol(Znew) == ncol(Z), anyNA(Znew) == FALSE)
   }
   if (!is.null(knots)) { 
-    if (class(knots) != "matrix")  knots <- as.matrix(knots)
+    if (!inherits(knots, "matrix"))  knots <- as.matrix(knots)
     stopifnot(is.numeric(knots), ncol(knots )== ncol(Z), anyNA(knots) == FALSE)
   }
   if (!is.null(groups)) { 
@@ -201,7 +201,7 @@ kmbayes <- function(y, Z, X = NULL, iter = 1000, family = "gaussian", id = NULL,
   ## components to predict h(Znew)
   if (!is.null(Znew)) {
     if (is.null(dim(Znew))) Znew <- matrix(Znew, nrow=1)
-    if (class(Znew) == "data.frame") Znew <- data.matrix(Znew)
+    if (inherits(Znew, "data.frame")) Znew <- data.matrix(Znew)
     if (ncol(Z) != ncol(Znew)) {
       stop("Znew must have the same number of columns as Z")
     }

--- a/R/bkmr_parameter_update_functions.R
+++ b/R/bkmr_parameter_update_functions.R
@@ -248,7 +248,7 @@ h.update <- function(lambda, Vcomps, sigsq.eps, y, X, beta, r, Z, data.comps) {
 		##h.postvar <- sigsq.eps*lamKVinv
 		h.postvar <- sigsq.eps*lambda*(K - lamKVinv%*%K)
 		h.postvar.sqrt <- try(chol(h.postvar), silent=TRUE)
-		if(class(h.postvar.sqrt) == "try-error") {
+		if(inherits(h.postvar.sqrt, "try-error")) {
 			sigsvd <- svd(h.postvar)
 			h.postvar.sqrt <- t(sigsvd$v %*% (t(sigsvd$u) * sqrt(sigsvd$d)))
 		}
@@ -287,7 +287,7 @@ newh.update <- function(Z, Znew, Vcomps, lambda, sigsq.eps, r, y, X, beta, data.
 		Sigma.hnew <- lambda[1]*sigsq.eps*(Kmat1 - lamK10Vinv %*% t(Kmat10))
 		mu.hnew <- lamK10Vinv %*% (y - X%*%beta)
 		root.Sigma.hnew <- try(chol(Sigma.hnew), silent=TRUE)
-		if(class(root.Sigma.hnew) == "try-error") {
+		if(inherits(root.Sigma.hnew, "try-error")) {
 			sigsvd <- svd(Sigma.hnew)
 			root.Sigma.hnew <- t(sigsvd$v %*% (t(sigsvd$u) * sqrt(sigsvd$d)))
 		}


### PR DESCRIPTION
Checking the class of an object with if(class(x) == "foo") produces a warning if the class of an object is a vector with length > 1 (as it seems to be for matrices now). Using 'inherits()' achieves the same result but removes the warning. This is a new problem in R 4.0.0 because matrices have a new class.