### PR TITLE
makeKpart and print diagnostics optimisations

### DIFF
--- a/R/bkmr_main_functions.R
+++ b/R/bkmr_main_functions.R
@@ -343,6 +343,14 @@ kmbayes <- function(y, Z, X = NULL, iter = 1000, family = "gaussian", id = NULL,
   ## components
   Vcomps <- makeVcomps(r = chain$r[1, ], lambda = chain$lambda[1, ], Z = Z, data.comps = data.comps)
 
+  # set print progress options
+  opts <- set_verbose_opts(
+    verbose_freq = control.params$verbose_freq, 
+    verbose_digits = control.params$verbose_digits,
+    verbose_show_ests = control.params$verbose_show_ests,
+    tot_iter=nsamp
+  )
+  
   ## start sampling ####
   chain$time1 <- Sys.time()
   for (s in 2:nsamp) {
@@ -439,11 +447,6 @@ kmbayes <- function(y, Z, X = NULL, iter = 1000, family = "gaussian", id = NULL,
     
     ###################################################
     ## print details of the model fit so far
-    opts <- set_verbose_opts(
-      verbose_freq = control.params$verbose_freq, 
-      verbose_digits = control.params$verbose_digits,
-      verbose_show_ests = control.params$verbose_show_ests
-      )
     print_diagnostics(verbose = verbose, opts = opts, curr_iter = s, tot_iter = nsamp, chain = chain, varsel = varsel, hier_varsel = hier_varsel, ztest = ztest, Z = Z, groups = groups)
    
   }

--- a/R/bkmr_main_functions.R
+++ b/R/bkmr_main_functions.R
@@ -3,13 +3,13 @@
 # Kpart
 # }
 makeKpart <- function(r, Z1, Z2 = NULL) {
-  Z1r <- sweep(Z1, 2, sqrt(r), "*")
+  Z1r <- t(t(Z1) * c(sqrt(r)))
   if (is.null(Z2)) {
-    Z2r <- Z1r
+    Kpart <- fields::rdist(Z1r)^2
   } else {
-    Z2r <- sweep(Z2, 2, sqrt(r), "*")
+    Z2r <- t(t(Z2) * c(sqrt(r)))
+    Kpart <- fields::rdist(Z1r, Z2r)^2
   }
-  Kpart <- fields::rdist(Z1r, Z2r)^2
   Kpart
 }
 makeVcomps <- function(r, lambda, Z, data.comps) {

--- a/R/bkmr_main_functions.R
+++ b/R/bkmr_main_functions.R
@@ -396,7 +396,14 @@ kmbayes <- function(y, Z, X = NULL, iter = 1000, family = "gaussian", id = NULL,
     comp <- which(!1:ncol(Z) %in% ztest)
     if (length(comp) != 0) {
       if (rmethod == "equal") { ## common r for those variables not being selected
-        varcomps <- r.update(r = rSim, whichcomp = comp, delta = chain$delta[s - 1,], lambda = chain$lambda[s,], y = ycont, X = X, beta = chain$beta[s,], sigsq.eps = chain$sigsq.eps[s], Vcomps = Vcomps, Z = Z, data.comps = data.comps, control.params = control.params, rprior.logdens = rprior.logdens, rprop.gen1 = rprop.gen1, rprop.logdens1 = rprop.logdens1, rprop.gen2 = rprop.gen2, rprop.logdens2 = rprop.logdens2, rprop.gen = rprop.gen, rprop.logdens = rprop.logdens)
+        varcomps <- r.update(r = rSim, whichcomp = comp, delta = chain$delta[s - 1,],
+                             lambda = chain$lambda[s,], y = ycont, X = X, beta = chain$beta[s,],
+                             sigsq.eps = chain$sigsq.eps[s], Vcomps = Vcomps, Z = Z,
+                             data.comps = data.comps, control.params = control.params,
+                             rprior.logdens = rprior.logdens, rprop.gen1 = rprop.gen1,
+                             rprop.logdens1 = rprop.logdens1, rprop.gen2 = rprop.gen2,
+                             rprop.logdens2 = rprop.logdens2, rprop.gen = rprop.gen,
+                             rprop.logdens = rprop.logdens)
         rSim <- varcomps$r
         if (varcomps$acc) {
           Vcomps <- varcomps$Vcomps
@@ -404,7 +411,14 @@ kmbayes <- function(y, Z, X = NULL, iter = 1000, family = "gaussian", id = NULL,
         }
       } else if (rmethod == "varying") { ## allow a different r_m
         for (whichr in comp) {
-          varcomps <- r.update(r = rSim, whichcomp = whichr, delta = chain$delta[s - 1,], lambda = chain$lambda[s,], y = ycont, X = X, beta = chain$beta[s,], sigsq.eps = chain$sigsq.eps[s], Vcomps = Vcomps, Z = Z, data.comps = data.comps, control.params = control.params, rprior.logdens = rprior.logdens, rprop.gen1 = rprop.gen1, rprop.logdens1 = rprop.logdens1, rprop.gen2 = rprop.gen2, rprop.logdens2 = rprop.logdens2, rprop.gen = rprop.gen, rprop.logdens = rprop.logdens)
+          varcomps <- r.update(r = rSim, whichcomp = whichr, delta = chain$delta[s - 1,],
+                               lambda = chain$lambda[s,], y = ycont, X = X, beta = chain$beta[s,],
+                               sigsq.eps = chain$sigsq.eps[s], Vcomps = Vcomps, Z = Z,
+                               data.comps = data.comps, control.params = control.params,
+                               rprior.logdens = rprior.logdens, rprop.gen1 = rprop.gen1,
+                               rprop.logdens1 = rprop.logdens1, rprop.gen2 = rprop.gen2,
+                               rprop.logdens2 = rprop.logdens2, rprop.gen = rprop.gen,
+                               rprop.logdens = rprop.logdens)
           rSim <- varcomps$r
           if (varcomps$acc) {
             Vcomps <- varcomps$Vcomps
@@ -415,7 +429,15 @@ kmbayes <- function(y, Z, X = NULL, iter = 1000, family = "gaussian", id = NULL,
     }
     ## for those variables being selected: joint posterior of (r,delta)
     if (varsel) {
-      varcomps <- rdelta.update(r = rSim, delta = chain$delta[s - 1,], lambda = chain$lambda[s,], y = ycont, X = X, beta = chain$beta[s,], sigsq.eps = chain$sigsq.eps[s], Vcomps = Vcomps, Z = Z, ztest = ztest, data.comps = data.comps, control.params = control.params, rprior.logdens = rprior.logdens, rprop.gen1 = rprop.gen1, rprop.logdens1 = rprop.logdens1, rprop.gen2 = rprop.gen2, rprop.logdens2 = rprop.logdens2, rprop.gen = rprop.gen, rprop.logdens = rprop.logdens)
+      varcomps <- rdelta.update(r = rSim, delta = chain$delta[s - 1,],
+                                lambda = chain$lambda[s,], y = ycont, X = X,
+                                beta = chain$beta[s,], sigsq.eps = chain$sigsq.eps[s],
+                                Vcomps = Vcomps, Z = Z, ztest = ztest,
+                                data.comps = data.comps, control.params = control.params,
+                                rprior.logdens = rprior.logdens, rprop.gen1 = rprop.gen1,
+                                rprop.logdens1 = rprop.logdens1, rprop.gen2 = rprop.gen2,
+                                rprop.logdens2 = rprop.logdens2, rprop.gen = rprop.gen,
+                                rprop.logdens = rprop.logdens)
       chain$delta[s,] <- varcomps$delta
       rSim <- varcomps$r
       chain$move.type[s] <- varcomps$move.type

--- a/R/print_verbose.R
+++ b/R/print_verbose.R
@@ -8,29 +8,37 @@
 #'
 #' @export
 #'
-set_verbose_opts <- function(verbose_freq = NULL, verbose_show_ests = NULL, verbose_digits = NULL) {
+
+set_verbose_opts <- function(verbose_freq = NULL, verbose_show_ests = NULL, verbose_digits = NULL,
+                             tot_iter) {
   if (is.null(verbose_freq)) verbose_freq <- 10
   if (is.null(verbose_digits)) verbose_digits <- 5
   if (is.null(verbose_show_ests)) verbose_show_ests <- FALSE
+  
+  all_iter <- 100*(1:tot_iter)/tot_iter
+  sel_iter <- seq(verbose_freq, 100, by = verbose_freq)
+  print_iter <- sapply(sel_iter, function(x) min(which(all_iter >= x)))
+  
   opts <- list(
     verbose_freq = verbose_freq,
     verbose_digits = verbose_digits,
-    verbose_show_ests = verbose_show_ests
-    )
+    verbose_show_ests = verbose_show_ests,
+    print_iter = print_iter
+  )
   opts
 }
+
+
 
 print_diagnostics <- function(verbose, opts, curr_iter, tot_iter, chain, varsel, hier_varsel, ztest, Z, groups) {
   verbose_freq <- opts$verbose_freq
   verbose_digits <- opts$verbose_digits
   verbose_show_ests <- opts$verbose_show_ests
+  print_iter <- opts$print_iter
+
   s <- curr_iter
   nsamp <- tot_iter
   perc_iter_completed <- round(100*curr_iter/tot_iter, 1)
-  
-  all_iter <- 100*(1:nsamp)/nsamp
-  sel_iter <- seq(verbose_freq, 100, by = verbose_freq)
-  print_iter <- sapply(sel_iter, function(x) min(which(all_iter >= x)))
   
   elapsed_time <- difftime(Sys.time(), chain$time1)
   


### PR DESCRIPTION
Hi. I made a few small changes to makeKpart that make it a bit faster.
There's 2 reasons for speed ups with these changes:

1. `t(t(Z1) * c(sqrt(r)))` is faster than `sweep(Z1, 2, sqrt(r), "*")`
2. By moving the call to `fields::rdist()` calculation into the if else statement, you get a marginal improvement when only the `Z1` argument is passed.

Making some test data as per bkmr website:
```
set.seed(111)
dat <- SimData(n = 50, M = 4)
y <- dat$y
Z <- dat$Z
X <- dat$X

z1 <- seq(min(dat$Z[, 1]), max(dat$Z[, 1]), length = 20)
z2 <- seq(min(dat$Z[, 2]), max(dat$Z[, 2]), length = 20)
hgrid.true <- outer(z1, z2, function(x,y) apply(cbind(x,y), 1, dat$HFun))

res <- persp(z1, z2, hgrid.true, theta = 30, phi = 20, expand = 0.5, 
             col = "lightblue", xlab = "", ylab = "", zlab = "")
```

And then fit timings from the current master bkmr:
<img width="690" alt="Screenshot 2021-10-01 at 09 22 45" src="https://user-images.githubusercontent.com/41968663/135582977-7df7d682-eea1-41b9-9b96-62bceb9950c0.png">

and after making change 1) + 2):
<img width="750" alt="Screenshot 2021-10-01 at 09 26 44" src="https://user-images.githubusercontent.com/41968663/135583133-3622c3f8-d16d-4ced-95b5-d4fd2c88120d.png">

